### PR TITLE
add test example using jsonextensiondata

### DIFF
--- a/tests/FMData.Rest.Tests/FindAsync.AdditionalData.cs
+++ b/tests/FMData.Rest.Tests/FindAsync.AdditionalData.cs
@@ -1,0 +1,45 @@
+using FMData.Rest.Requests;
+using FMData.Rest.Tests.TestModels;
+using RichardSzalay.MockHttp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FMData.Rest.Tests
+{
+    public class FindAsyncAdditionalData
+    {
+        [Fact]
+        public async Task FindAsync_Should_Handle_Extra_Data()
+        {
+            // arrange
+            var mockHttp = new MockHttpMessageHandler();
+
+            var layout = "Users";
+
+            mockHttp.When(HttpMethod.Post, $"{FindTestsHelpers.server}/fmi/data/v1/databases/{FindTestsHelpers.file}/sessions")
+                           .Respond("application/json", DataApiResponses.SuccessfulAuthentication());
+
+            mockHttp.When(HttpMethod.Post, $"{FindTestsHelpers.server}/fmi/data/v1/databases/{FindTestsHelpers.file}/layouts/{layout}/_find")
+                .WithPartialContent("limit") // ensure the request contains the expected content
+                .WithPartialContent("offset") // ensure the request contains the expected content
+                .Respond("application/json", DataApiResponses.SuccessfulFind());
+
+            var fdc = new FileMakerRestClient(mockHttp.ToHttpClient(), FindTestsHelpers.Connection);
+
+            // act
+            var response = await fdc.FindAsync(new AdditionalDataUser()
+            {
+                Name = "fuzzzerd"
+            }, 5, 5);
+            var user = response.First();
+
+            // assert
+            Assert.NotEmpty(user.AdditionalData);
+        }
+    }
+}

--- a/tests/FMData.Rest.Tests/TestModels/AdditionalDataUser.cs
+++ b/tests/FMData.Rest.Tests/TestModels/AdditionalDataUser.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FMData.Rest.Tests.TestModels
+{
+    [DataContract(Name = "Users")]
+    public class AdditionalDataUser
+    {
+        [IgnoreDataMember] public int FileMakerRecordId { get; set; }
+        [IgnoreDataMember] public int FileMakerModId { get; set; }
+        [DataMember] public int Id { get; set; }
+        [DataMember] public int? ForeignKeyId { get; set; }
+        [DataMember] public string Name { get; set; }
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+}


### PR DESCRIPTION
Shows an example of using `[JsonExtensionData]` to populate additional fields on the base model that don't match.