### PR TITLE
FileMaker Cloud Authentication

### DIFF
--- a/FMData.sln
+++ b/FMData.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMData.Xml", "src\FMData.Xm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMData.Xml.Tests", "tests\FMData.Xml.Tests\FMData.Xml.Tests.csproj", "{36143397-0EED-4CA4-9D25-C60A8C93B1FA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMData.Rest.Auth.FileMakerCloud", "src\FMData.Rest.Auth.Cloud\FMData.Rest.Auth.FileMakerCloud.csproj", "{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +97,18 @@ Global
 		{36143397-0EED-4CA4-9D25-C60A8C93B1FA}.Release|x64.Build.0 = Release|Any CPU
 		{36143397-0EED-4CA4-9D25-C60A8C93B1FA}.Release|x86.ActiveCfg = Release|Any CPU
 		{36143397-0EED-4CA4-9D25-C60A8C93B1FA}.Release|x86.Build.0 = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|x64.Build.0 = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Debug|x86.Build.0 = Debug|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|x64.ActiveCfg = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|x64.Build.0 = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|x86.ActiveCfg = Release|Any CPU
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,6 +119,7 @@ Global
 		{DF7C8CD9-D26F-4A66-A3C4-95A6E7EF269E} = {6926CF2C-9411-467D-AC6F-06B18C3A41B6}
 		{2CB7F5C1-7D49-4ADE-B137-831D5653958B} = {6926CF2C-9411-467D-AC6F-06B18C3A41B6}
 		{36143397-0EED-4CA4-9D25-C60A8C93B1FA} = {FC1158B5-9752-46DE-B885-B8B553E252B2}
+		{36772074-2B2B-4FB5-8A48-7F4EA1FB1233} = {6926CF2C-9411-467D-AC6F-06B18C3A41B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13001953-EB62-4CE6-82B1-3795390B514E}

--- a/src/FMData.Rest.Auth.Cloud/FMData.Rest.Auth.FileMakerCloud.csproj
+++ b/src/FMData.Rest.Auth.Cloud/FMData.Rest.Auth.FileMakerCloud.csproj
@@ -52,19 +52,6 @@
     <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netstandard1.3'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'net45'">
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'net45'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication">
       <Version>2.2.2</Version>

--- a/src/FMData.Rest.Auth.Cloud/FMData.Rest.Auth.FileMakerCloud.csproj
+++ b/src/FMData.Rest.Auth.Cloud/FMData.Rest.Auth.FileMakerCloud.csproj
@@ -1,0 +1,99 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <AssemblyTitle>FMData.Rest.Auth.FileMakerCloud</AssemblyTitle>
+    <AssemblyName>FMData.Rest.Auth.FileMakerCloud</AssemblyName>
+    <Description>FileMaker Data API Authentication for FileMaker Cloud.</Description>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <PackageLicense>https://github.com/fuzzzerd/fmdata/blob/master/LICENSE</PackageLicense>
+    <PackageProjectUrl>https://fmdata.io/</PackageProjectUrl>
+    <PackageIcon>nuget.png</PackageIcon>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/fuzzzerd/fmdata</RepositoryUrl>
+    <RepositoryType>GitHub</RepositoryType>
+    <Authors>Nate Bross</Authors>
+    <Company />
+    <PackageTags>data-api filemaker dataapi dapi-client data dapi api filemaker-rest filemaker-api netstandard json dotnet-standard</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>Embedded</DebugType>
+    <IncludeUntrackedSources>true</IncludeUntrackedSources>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(CI)' == 'true'">
+   <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />
+ </ItemGroup>
+
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>4.3</MinVerMinimumMajorMinor>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleasePhase>beta</MinVerDefaultPreReleasePhase>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\images\nuget.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FMData\FMData.csproj" />
+  <ProjectReference Include="..\FMData.Rest\FMData.Rest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard1.3'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net45'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net45'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Amazon.Extensions.CognitoAuthentication">
+      <Version>2.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider">
+      <Version>3.7.4</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Amazon.Extensions.CognitoAuthentication">
+      <Version>2.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider">
+      <Version>3.7.4</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider">
+      <Version>3.7.4</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="MyTarget" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">
+    <PropertyGroup>
+      <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID).$(MinVerPreRelease)</PackageVersion>
+      <PackageVersion Condition="'$(MinVerBuildMetadata)' != ''">$(PackageVersion)+$(MinVerBuildMetadata)</PackageVersion>
+      <Version>$(PackageVersion)</Version>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/FMData.Rest.Auth.Cloud/FileMakerCloudAuthTokenProvider.cs
+++ b/src/FMData.Rest.Auth.Cloud/FileMakerCloudAuthTokenProvider.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.CognitoIdentityProvider;
+using Amazon.Extensions.CognitoAuthentication;
+using Amazon.Runtime;
+
+namespace FMData.Rest
+{
+    /// <summary>
+    /// FileMaker Cloud authentication provider (AWS Cognito)
+    /// </summary>
+    public class FileMakerCloudAuthTokenProvider : IAuthTokenProvider
+    {
+        /// <summary>
+        /// Username for connections.
+        /// </summary>
+        protected readonly ConnectionInfo Conn;
+
+        /// <summary>
+        /// Constructor 
+        /// </summary>
+        /// <param name="conn">ConnectionInfo</param>
+        public FileMakerCloudAuthTokenProvider(ConnectionInfo conn)
+        {
+            Conn = conn;
+        }
+
+        /// <summary>
+        /// Get base64 encoded AuthenticationHeaderValue
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue()
+        {
+            //we need an AWS cognito Id token for authentication
+            string token = await GetToken().ConfigureAwait(false);
+            return new AuthenticationHeaderValue("Authorization", "FMID " + token);
+        }
+
+        /// <summary>
+        /// Provide an AWS Cognito Identiy Token
+        /// </summary>
+        private async Task<string> GetToken()
+        {
+            var provider = new AmazonCognitoIdentityProviderClient(new AnonymousAWSCredentials(), Amazon.RegionEndpoint.USWest2);
+            var userpool = new CognitoUserPool(Conn.CognitoUserPoolID, Conn.CognitoClientID, provider);
+            var user = new CognitoUser(Conn.Username, Conn.CognitoClientID, userpool, provider);
+            var initiateSrpAuthRequest = new InitiateSrpAuthRequest();
+            initiateSrpAuthRequest.Password = Conn.Password;
+
+            var response = await user.StartWithSrpAuthAsync(initiateSrpAuthRequest).ConfigureAwait(false);
+            return response.AuthenticationResult.IdToken;
+        }
+    }
+}

--- a/src/FMData.Rest.Auth.Cloud/FileMakerCloudAuthTokenProvider.cs
+++ b/src/FMData.Rest.Auth.Cloud/FileMakerCloudAuthTokenProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Net.Http.Headers;
-using System.Text;
+﻿using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Amazon.CognitoIdentityProvider;
 using Amazon.Extensions.CognitoAuthentication;
@@ -13,30 +11,30 @@ namespace FMData.Rest
     /// </summary>
     public class FileMakerCloudAuthTokenProvider : IAuthTokenProvider
     {
-        /// <summary>
-        /// Username for connections.
-        /// </summary>
-        protected readonly ConnectionInfo Conn;
+        private readonly ConnectionInfo _conn;
 
         /// <summary>
         /// Constructor 
         /// </summary>
-        /// <param name="conn">ConnectionInfo</param>
+        /// <param name="conn">Connection config values</param>
         public FileMakerCloudAuthTokenProvider(ConnectionInfo conn)
         {
-            Conn = conn;
+            _conn = conn;
         }
 
         /// <summary>
-        /// Get base64 encoded AuthenticationHeaderValue
+        /// Connection config values
         /// </summary>
-        /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        public ConnectionInfo Conn { get => _conn; }
+
+        /// <summary>
+        /// Gets the AuthenticationHeaderValue
+        /// </summary>
+        /// <returns>AuthenticationHeaderValue</returns>
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue()
         {
-            //we need an AWS cognito Id token for authentication
             string token = await GetToken().ConfigureAwait(false);
-            return new AuthenticationHeaderValue("Authorization", "FMID " + token);
+            return AuthenticationHeaderValue.Parse("FMID " + token);
         }
 
         /// <summary>

--- a/src/FMData.Rest/DefaultAuthTokenProvider.cs
+++ b/src/FMData.Rest/DefaultAuthTokenProvider.cs
@@ -10,25 +10,21 @@ namespace FMData.Rest
     /// </summary>
     public class DefaultAuthTokenProvider : IAuthTokenProvider
     {
-        /// <summary>
-        /// Username for connections.
-        /// </summary>
-        protected readonly string Username;
-        /// <summary>
-        /// Password for connections.
-        /// </summary>
-        protected readonly string Password;
+        private readonly ConnectionInfo _conn;
 
         /// <summary>
         /// Constructor 
         /// </summary>
-        /// <param name="username">Username to use when making the connection.</param>
-        /// <param name="password">Password to use when making the connection.</param>
-        public DefaultAuthTokenProvider(string username, string password)
+        /// <param name="conn">Provide Connection details</param>
+        public DefaultAuthTokenProvider(ConnectionInfo conn)
         {
-            Username = username;
-            Password = password;
+            _conn = conn;
         }
+
+        /// <summary>
+        /// Connection config values
+        /// </summary>
+        public ConnectionInfo Conn { get => _conn; }
 
         /// <summary>
         /// Get base64 encoded AuthenticationHeaderValue
@@ -37,9 +33,9 @@ namespace FMData.Rest
         /// <exception cref="System.NotImplementedException"></exception>
         public Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue()
         {
-            if (string.IsNullOrEmpty(Username)) throw new ArgumentException("Username is a required parameter.");
-            if (string.IsNullOrEmpty(Password)) throw new ArgumentException("Password is a required parameter.");
-            var header = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Username}:{Password}")));
+            if (string.IsNullOrEmpty(Conn.Username)) throw new ArgumentException("Username is a required parameter.");
+            if (string.IsNullOrEmpty(Conn.Password)) throw new ArgumentException("Password is a required parameter.");
+            var header = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Conn.Username}:{Conn.Password}")));
             return Task.FromResult(header);
         }
     }

--- a/src/FMData.Rest/DefaultAuthTokenProvider.cs
+++ b/src/FMData.Rest/DefaultAuthTokenProvider.cs
@@ -24,18 +24,18 @@ namespace FMData.Rest
         /// <summary>
         /// Connection config values
         /// </summary>
-        public ConnectionInfo Conn { get => _conn; }
+        public ConnectionInfo ConnectionInfo { get => _conn; }
 
         /// <summary>
         /// Get base64 encoded AuthenticationHeaderValue
         /// </summary>
         /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         public Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue()
         {
-            if (string.IsNullOrEmpty(Conn.Username)) throw new ArgumentException("Username is a required parameter.");
-            if (string.IsNullOrEmpty(Conn.Password)) throw new ArgumentException("Password is a required parameter.");
-            var header = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Conn.Username}:{Conn.Password}")));
+            if (string.IsNullOrEmpty(_conn.Username)) throw new ArgumentException("Username is a required parameter.");
+            if (string.IsNullOrEmpty(_conn.Password)) throw new ArgumentException("Password is a required parameter.");
+            var header = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_conn.Username}:{_conn.Password}")));
             return Task.FromResult(header);
         }
     }

--- a/src/FMData.Rest/DefaultAuthTokenProvider.cs
+++ b/src/FMData.Rest/DefaultAuthTokenProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FMData.Rest
+{
+    /// <summary>
+    /// Default authentication provider
+    /// </summary>
+    public class DefaultAuthTokenProvider : IAuthTokenProvider
+    {
+        /// <summary>
+        /// Username for connections.
+        /// </summary>
+        protected readonly string Username;
+        /// <summary>
+        /// Password for connections.
+        /// </summary>
+        protected readonly string Password;
+
+        /// <summary>
+        /// Constructor 
+        /// </summary>
+        /// <param name="username">Username to use when making the connection.</param>
+        /// <param name="password">Password to use when making the connection.</param>
+        public DefaultAuthTokenProvider(string username, string password)
+        {
+            Username = username;
+            Password = password;
+        }
+
+        /// <summary>
+        /// Get base64 encoded AuthenticationHeaderValue
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue()
+        {
+            if (string.IsNullOrEmpty(Username)) throw new ArgumentException("Username is a required parameter.");
+            if (string.IsNullOrEmpty(Password)) throw new ArgumentException("Password is a required parameter.");
+            var header = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Username}:{Password}")));
+            return Task.FromResult(header);
+        }
+    }
+}

--- a/src/FMData.Rest/FileMakerRestClient.cs
+++ b/src/FMData.Rest/FileMakerRestClient.cs
@@ -79,7 +79,7 @@ namespace FMData.Rest
         /// <param name="client">The HttpClient instance to use.</param>
         /// <param name="authTokenProvider">Authentication provider</param>
         public FileMakerRestClient(HttpClient client, IAuthTokenProvider authTokenProvider)
-            : base(client, authTokenProvider.Conn)
+            : base(client, authTokenProvider.ConnectionInfo)
         {
             _authTokenProvider = authTokenProvider;
 #if NETSTANDARD1_3

--- a/src/FMData.Rest/FileMakerRestClient.cs
+++ b/src/FMData.Rest/FileMakerRestClient.cs
@@ -70,17 +70,16 @@ namespace FMData.Rest
         /// <param name="client">The HttpClient instance to use.</param>
         /// <param name="conn">The connection information for FMS.</param>
         public FileMakerRestClient(HttpClient client, ConnectionInfo conn)
-            : this(client, conn, new DefaultAuthTokenProvider(conn.Username, conn.Password))
+            : this(client, new DefaultAuthTokenProvider(conn))
         { }
 
         /// <summary>
         /// FM Data Constructor with HttpClient, ConnectionInfo and an authentication provider. Useful for Dependency Injection situations.
         /// </summary>
         /// <param name="client">The HttpClient instance to use.</param>
-        /// <param name="conn">The connection information for FMS.</param>
         /// <param name="authTokenProvider">Authentication provider</param>
-        public FileMakerRestClient(HttpClient client, ConnectionInfo conn, IAuthTokenProvider authTokenProvider)
-            : base(client, conn)
+        public FileMakerRestClient(HttpClient client, IAuthTokenProvider authTokenProvider)
+            : base(client, authTokenProvider.Conn)
         {
             _authTokenProvider = authTokenProvider;
 #if NETSTANDARD1_3

--- a/src/FMData.Rest/IAuthTokenProvider.cs
+++ b/src/FMData.Rest/IAuthTokenProvider.cs
@@ -11,7 +11,7 @@ namespace FMData.Rest
         /// <summary>
         /// Connection config values
         /// </summary>
-        ConnectionInfo Conn { get; }
+        ConnectionInfo ConnectionInfo { get; }
 
         /// <summary>
         /// Provide the AuthenticationHeaderValue

--- a/src/FMData.Rest/IAuthTokenProvider.cs
+++ b/src/FMData.Rest/IAuthTokenProvider.cs
@@ -4,10 +4,14 @@ using System.Threading.Tasks;
 namespace FMData.Rest
 {
     /// <summary>
-    /// FileMaker REST Client Auth Provider.
+    /// FileMaker REST Client Auth Provider Interface.
     /// </summary>
     public interface IAuthTokenProvider
     {
+        /// <summary>
+        /// Connection config values
+        /// </summary>
+        ConnectionInfo Conn { get; }
 
         /// <summary>
         /// Provide the AuthenticationHeaderValue

--- a/src/FMData.Rest/IAuthTokenProvider.cs
+++ b/src/FMData.Rest/IAuthTokenProvider.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace FMData.Rest
+{
+    /// <summary>
+    /// FileMaker REST Client Auth Provider.
+    /// </summary>
+    public interface IAuthTokenProvider
+    {
+
+        /// <summary>
+        /// Provide the AuthenticationHeaderValue
+        /// </summary>
+        /// <returns>AuthenticationHeaderValue</returns>
+        Task<AuthenticationHeaderValue> GetAuthenticationHeaderValue();
+    }
+}

--- a/src/FMData.Rest/IFileMakerRestClient.cs
+++ b/src/FMData.Rest/IFileMakerRestClient.cs
@@ -13,12 +13,8 @@ namespace FMData.Rest
         /// <summary>
         /// Refreshes the internally stored authentication token from filemaker server.
         /// </summary>
-        /// <param name="username">Username of the account to authenticate.</param>
-        /// <param name="password">Password of the account to authenticate.</param>
         /// <returns>An AuthResponse from deserialized from FileMaker Server json response.</returns>
-        Task<AuthResponse> RefreshTokenAsync(
-            string username,
-            string password);
+        Task<AuthResponse> RefreshTokenAsync();
 
         /// <summary>
         /// Logs the user out and nullifies the token.

--- a/src/FMData/ConnectionInfo.cs
+++ b/src/FMData/ConnectionInfo.cs
@@ -1,4 +1,4 @@
-namespace FMData
+﻿namespace FMData
 {
     /// <summary>
     /// Represents the connection information for FMS.
@@ -21,5 +21,13 @@ namespace FMData
         /// Password to use when making the connection.
         /// </summary>
         public string Password { get; set; }
+        /// <summary>
+        /// AWS Cognito UserPoolID
+        /// </summary>
+        public string CognitoUserPoolID { get; set; } = "us-west-2_NqkuZcXQY";
+        /// <summary>
+        /// AWS Cognito ClientID
+        /// </summary>
+        public string CognitoClientID { get; set; } = "4l9rvl4mv5es1eep1qe97cautn";
     }
 }

--- a/src/FMData/ConnectionInfo.cs
+++ b/src/FMData/ConnectionInfo.cs
@@ -21,13 +21,35 @@
         /// Password to use when making the connection.
         /// </summary>
         public string Password { get; set; }
+
+        #region FileMaker Cloud
+
+        /*
+         * Using Claris ID for authentication
+         * -------------------------------------------
+         * If you want to use the FileMaker Data API with FileMaker Cloud, you must authenticate using your Claris ID account.
+         * FileMaker Cloud uses Amazon Cognito for authentication.
+         * 
+         * FileMaker Cloud provides the following endpoint to gather the required informations:
+         * https://www.ifmcloud.com/endpoint/userpool/2.2.0.my.claris.com.json 
+         */
+
         /// <summary>
         /// AWS Cognito UserPoolID
+        /// <see href="https://www.ifmcloud.com/endpoint/userpool/2.2.0.my.claris.com.json">data.UserPool_ID</see>
         /// </summary>
         public string CognitoUserPoolID { get; set; } = "us-west-2_NqkuZcXQY";
         /// <summary>
         /// AWS Cognito ClientID
+        /// <see href="https://www.ifmcloud.com/endpoint/userpool/2.2.0.my.claris.com.json">data.Client_ID</see>
         /// </summary>
         public string CognitoClientID { get; set; } = "4l9rvl4mv5es1eep1qe97cautn";
+        /// <summary>
+        /// AWS Cognito Region
+        /// <see href="https://www.ifmcloud.com/endpoint/userpool/2.2.0.my.claris.com.json">data.Region</see>
+        /// </summary>
+        public string RegionEndpoint { get; set; } = "us-west-2";
+
+        #endregion
     }
 }

--- a/tests/FMData.Rest.Tests/AuthenticationTests.cs
+++ b/tests/FMData.Rest.Tests/AuthenticationTests.cs
@@ -1,4 +1,4 @@
-using RichardSzalay.MockHttp;
+﻿using RichardSzalay.MockHttp;
 using System;
 using System.Linq;
 using System.Net;
@@ -73,7 +73,7 @@ namespace FMData.Rest.Tests
                 .Respond(HttpStatusCode.OK, "application/json", "");
 
             using var fdc = new FileMakerRestClient(mockHttp.ToHttpClient(), new ConnectionInfo { FmsUri = server, Database = file, Username = user, Password = pass });
-            var response = await fdc.RefreshTokenAsync("integration", "test");
+            var response = await fdc.RefreshTokenAsync();
             Assert.Equal("someOtherToken", response.Response.Token);
         }
 
@@ -95,7 +95,7 @@ namespace FMData.Rest.Tests
 
             // pass in actual values here since we DON'T want this to blow up on constructor 
             using var fdc = new FileMakerRestClient(mockHttp.ToHttpClient(), new ConnectionInfo { FmsUri = server, Database = file, Username = user, Password = pass });
-            await Assert.ThrowsAsync<ArgumentException>(async () => await fdc.RefreshTokenAsync(user, pass));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await fdc.RefreshTokenAsync());
         }
 
         [Fact(DisplayName = "User-Agent Should Match Version Of Assembly")]
@@ -120,7 +120,7 @@ namespace FMData.Rest.Tests
                 .Respond(HttpStatusCode.OK, "application/json", "");
 
             using var fdc = new FileMakerRestClient(mockHttp.ToHttpClient(), new ConnectionInfo { FmsUri = server, Database = file, Username = user, Password = pass });
-            await fdc.RefreshTokenAsync(user, pass);
+            await fdc.RefreshTokenAsync();
             Assert.True(fdc.IsAuthenticated);
         }
     }

--- a/tests/FMData.Rest.Tests/FindAsync.Tests.cs
+++ b/tests/FMData.Rest.Tests/FindAsync.Tests.cs
@@ -3,6 +3,7 @@ using FMData.Rest.Tests.TestModels;
 using RichardSzalay.MockHttp;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -66,7 +67,7 @@ namespace FMData.Rest.Tests
             }, "nos_ran", null, null);
 
             // assert
-            var responseDataContainsResult = response.Any(r => r.Created == DateTime.Parse("03/29/2018 15:22:09"));
+            var responseDataContainsResult = response.Any(r => r.Created == DateTime.ParseExact("03/29/2018 15:22:09", "MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture));
             Assert.True(responseDataContainsResult);
         }
 

--- a/tests/FMData.Rest.Tests/GeneralTests.cs
+++ b/tests/FMData.Rest.Tests/GeneralTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.Serialization;
@@ -191,7 +192,7 @@ namespace FMData.Rest.Tests
             });
 
             // assert
-            var responseDataContainsResult = response.Any(r => r.Created == DateTime.Parse("03/29/2018 15:22:09"));
+            var responseDataContainsResult = response.Any(r => r.Created == DateTime.ParseExact("03/29/2018 15:22:09", "MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture));
             Assert.True(responseDataContainsResult);
         }
     }


### PR DESCRIPTION
Finally I found some time to work on the FileMakerCloud Authentication. Some thoughts regarding this pull request:

- As you have suggested, I've placed the aws packages in a separate project with the name FMData.Rest.Auth.FileMakerCloud
- I thought it's important to have the "full marketing name" at the end (FileMakerCloud), so that newcomers will easily understand the principle and that "following" implementations (Google, Microsoft Azure AD) will/can fall in place.
- The AWSSDK.CognitoIdentityProvider is not compatible with netstandard1.3 - this is why I have removed it from the target frameworks in the new project
- The  Amazon.Extensions.CognitoAuthentication is not compatible with net45 - this is why I have removed it from the target frameworks in the new project
- I have added a new ctor in FileMakerRestClient, which is used like:
`new FileMakerRestClient(new HttpClient(), new FileMakerCloudAuthTokenProvider(conn));`


What do you think? I'm happy to discuss and improve.
Currently I do have access to a FileMakerCloud account and can test.

regards,

Renato
