### PR TITLE
Revert "chore(deps): bump moq from 4.18.4 to 4.20.0"

### DIFF
--- a/tests/FMData.Rest.Tests/FMData.Rest.Tests.csproj
+++ b/tests/FMData.Rest.Tests/FMData.Rest.Tests.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="moq" Version="4.20.0" />
+    <PackageReference Include="moq" Version="4.18.4" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit.runner.console" Version="2.5.0" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/tests/FMData.Xml.Tests/FMData.Xml.Tests.csproj
+++ b/tests/FMData.Xml.Tests/FMData.Xml.Tests.csproj
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="moq" Version="4.20.0" />
+    <PackageReference Include="moq" Version="4.18.4" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.console" Version="2.5.0" />


### PR DESCRIPTION
Reverts fuzzzerd/fmdata#298.

See also: https://github.com/moq/moq/issues/1372